### PR TITLE
clean up initial conditions to ensure directive is applied on page load as well as resize

### DIFF
--- a/src/fill-height.js
+++ b/src/fill-height.js
@@ -17,6 +17,8 @@
                     angular.element($window).on('resize', debounce(onWindowResize, scope.debounceWait || 250));
                 }
                 
+				angular.element($window).on('load', debounce(onWindowResize, scope.debounceWait || 250));
+				
                 onWindowResize();
                 
                 // returns a fn that will trigger 'time' amount after it stops getting called.

--- a/src/fill-height.js
+++ b/src/fill-height.js
@@ -17,7 +17,7 @@
                     angular.element($window).on('resize', debounce(onWindowResize, scope.debounceWait || 250));
                 }
                 
-				angular.element($window).on('ready', onWindowResize);
+				angular.element($window).on('load', onWindowResize);
 				                
                 // returns a fn that will trigger 'time' amount after it stops getting called.
                 function debounce(fn, time) {

--- a/src/fill-height.js
+++ b/src/fill-height.js
@@ -10,14 +10,15 @@
             },
             link: function (scope, element, attrs) {
                 if (scope.debounceWait === 0) {
-                    angular.element($window).on('resize', windowResize);
+                    angular.element($window).on('resize', onWindowResize);
                 } else {
                     // allow debounce wait time to be passed in.
                     // if not passed in, default to a reasonable 250ms
                     angular.element($window).on('resize', debounce(onWindowResize, scope.debounceWait || 250));
                 }
                 
-				angular.element($window).on('load', onWindowResize);
+				//call once the DOM is ready
+				$timeout(onWindowResize);
 				                
                 // returns a fn that will trigger 'time' amount after it stops getting called.
                 function debounce(fn, time) {

--- a/src/fill-height.js
+++ b/src/fill-height.js
@@ -17,10 +17,8 @@
                     angular.element($window).on('resize', debounce(onWindowResize, scope.debounceWait || 250));
                 }
                 
-				angular.element($window).on('load', debounce(onWindowResize, scope.debounceWait || 250));
-				
-                onWindowResize();
-                
+				angular.element($window).on('ready', onWindowResize);
+				                
                 // returns a fn that will trigger 'time' amount after it stops getting called.
                 function debounce(fn, time) {
                     var timeout;
@@ -61,7 +59,7 @@
                                         - footerElementHeight
                                         - additionalPadding;
 
-                    console.log(elementHeight);
+                    //console.info(elementHeight);
                     element.css('height', elementHeight + 'px');
                 }
 


### PR DESCRIPTION
Currently, directive does not seem to apply in some cases on first page load.
Directive is loaded before the page has finished loading, so first call to onWindowResize fails to set size correctly.
Also no need for debounce on page load.
